### PR TITLE
ci: Grant contents:write permission for Nightly CI workflow GITHUB_TOKEN

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Creating a release requires the contents:write permission on the workflow's GITHUB_TOKEN
+# Note: Specifying any permissions here overrides the defaults for any unspecified values to none
+permissions:
+  contents: write
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
I noticed that the Nightly Github Actions CI workflow seems to be encountering HTTP 403 errors when trying to submit a POST request to the Github API to create a release (https://github.com/t3mujinpack/t3mujinpack/actions/runs/14225640909/job/39864409978#step:5:79).

Based on the docs for controlling `GITHUB_TOKEN` permissions for Actions workflows, creating a release requires the workflow token to contain the `contents:write` permission (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token).

I've added a comment to this effect, but it's worth pointing out (in case of unexpected future permissions issues) that specifying any values under the `permissions` mapping overrides the default for any unspecified permissions to `none`. Based on a quick read through the implementations of the PyTooling/Actions/releaser Action, I believe this is the only token permission this workflow currently requires.